### PR TITLE
Handle JSON files; improve error handling; add Python bundler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build-pydocs.sh
+/pydoc/
+/wrappers/requirements.txt
+/wrappers/info.plist

--- a/bundler.sh
+++ b/bundler.sh
@@ -17,7 +17,7 @@ function __loadAsset {
 
   if [ -f "$__data/assets/$type/$name/$version/invoke" ]; then
     invoke=$(echo `cat "$__data/assets/$type/$name/$version/invoke"`)
-    if [ $invoke = 'null' ]; then
+    if [ "$invoke" = 'null' ]; then
       invoke=''
     fi
     if [ "$type" = "utility" ]; then
@@ -27,32 +27,37 @@ function __loadAsset {
     if [[ ! -z $bundle ]] && [[ $bundle != '..' ]]; then
       php "$__data/includes/registry.php" "$bundle" "$name" "$version" > /dev/null &
     fi
-    exit
+    return 0
   fi
   if [ -z "$json" ]; then
-    if [ -f "$__data/meta/defaults/$name.json" ]; then
-      php "$__data/includes/installAsset.php" "$__data/meta/defaults/$name.json" "$version"
-      if [ ! -z "$result" ]; then
-        echo "$result"
-        exit
-      fi
-      if [ -f "$__data/assets/$type/$name/$version/invoke" ]; then
-        invoke=$(echo `cat "$__data/assets/$type/$name/$version/invoke"`)
-        if [ $invoke = 'null' ]; then
-          invoke=''
-        fi
-        echo "$__data/assets/$type/$name/$version/$invoke"
-        if [[ ! -z $bundle ]] && [[ $bundle != '..' ]]; then
-          php "$__data/includes/registry.php" "$bundle" "$name" "$version" > /dev/null &
-        fi
-        if [ $type = 'utility' ]; then
-          if [ ! -z $invoke ]; then
-            sh "$__data/includes/gatekeeper.sh" "$name" "$__data/assets/$type/$name/$version/$invoke" > /dev/null
-          fi
-        fi
-        exit
-      fi
+    json="$__data/meta/defaults/$name.json"
+  fi
+  if [ -f "$json" ]; then
+    php "$__data/includes/installAsset.php" "$json" "$version"
+    if [ ! -z "$result" ]; then
+      echo "$result"
+      return 0
     fi
+    if [ -f "$__data/assets/$type/$name/$version/invoke" ]; then
+      invoke=$(echo `cat "$__data/assets/$type/$name/$version/invoke"`)
+      if [ "$invoke" = 'null' ]; then
+        invoke=''
+      fi
+      echo "$__data/assets/$type/$name/$version/$invoke"
+      if [[ ! -z "$bundle" ]] && [[ "$bundle" != '..' ]]; then
+        php "$__data/includes/registry.php" "$bundle" "$name" "$version" > /dev/null &
+      fi
+      if [ $type = 'utility' ]; then
+        if [ ! -z "$invoke" ]; then
+          sh "$__data/includes/gatekeeper.sh" "$name" "$__data/assets/$type/$name/$version/$invoke" > /dev/null
+        fi
+      fi
+      return 0
+    fi
+  else
+    echo "JSON file does not exist : $json"
+    return 1
   fi
   echo "You've encountered a problem with the __implementation__ of the Alfred Bundler; please let the workflow author know."
+  return 1
 }

--- a/meta/defaults/Pip.json
+++ b/meta/defaults/Pip.json
@@ -1,0 +1,18 @@
+{
+  "name": "Pip",
+  "type": "utility",
+  "versions": {
+    "default": {
+      "invoke": null,
+      "files": [
+        {
+          "url": "https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py",
+          "method": "direct"
+        }
+      ],
+      "install": [
+        "/usr/bin/python '__FILE__' --target='__DATA__'"
+      ]
+    }
+  }
+}

--- a/wrappers/.gitignore
+++ b/wrappers/.gitignore
@@ -1,0 +1,3 @@
+/info.plist
+/requirements.txt
+

--- a/wrappers/.gitignore
+++ b/wrappers/.gitignore
@@ -1,3 +1,0 @@
-/info.plist
-/requirements.txt
-

--- a/wrappers/alfred.bundler.misc.sh
+++ b/wrappers/alfred.bundler.misc.sh
@@ -46,8 +46,9 @@ fi
  fi
 
  __asset=`__loadAsset "$name" "$version" "$bundle" "$type" "$json"`
+ status=$?
  echo "$__asset"
-
+ return $status
 }
 
 # This just downloads the install script and starts it up.
@@ -78,3 +79,4 @@ fi
 sh "$__data/meta/update.sh" > /dev/null 2>&1
 
 __load "$1" "$2" "$3" "$4"
+exit $?

--- a/wrappers/bundler.py
+++ b/wrappers/bundler.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+
+"""
+Python implementation of the Alfred Bundler.
+
+NOTE: The installation of Python libraries is currently unfinished due
+to the bundler.sh script it depends on being broken.
+
+"""
+
+from __future__ import print_function, unicode_literals
+
+import sys
+import os
+import plistlib
+from urllib import urlretrieve
+import subprocess
+
+# Used to bump Pip recipe
+__version__ = '0.1'
+
+# Bundler paths
+BUNDLER_VERSION = 'aries'
+DATA_DIR = os.path.expanduser(
+    '~/Library/Application Support/Alfred 2/Workflow Data/'
+    'alfred.bundler-{}'.format(BUNDLER_VERSION))
+CACHE_DIR = os.path.expanduser(
+    '~/Library/Caches/com.runningwithcrayons.Alfred-2/Workflow Data/'
+    'alfred.bundler-{}'.format(BUNDLER_VERSION))
+# Where helper scripts will be installed
+HELPER_DIR = os.path.join(DATA_DIR, 'python-helpers')
+# Where installer.sh can be downloaded from
+HELPER_URL = ('https://raw.githubusercontent.com/shawnrice/alfred-bundler/'
+              '{}/wrappers/alfred.bundler.misc.sh'.format(BUNDLER_VERSION))
+# The bundler script we will call to get paths to utilities and
+# install them if necessary. This is actually the bash wrapper, not
+# the bundler.sh file in the repo
+HELPER_PATH = os.path.join(HELPER_DIR, 'bundlerwrapper.sh')
+# Root directory under which workflow-specific Python libraries are installed
+PYTHON_LIB_DIR = os.path.join(DATA_DIR, 'assets', 'python')
+# Path to locally cached version of Pip JSON recipe
+PIP_JSON_PATH = os.path.join(HELPER_DIR, 'pip-{}.json'.format(__version__))
+# JSON recipe for installing Pip
+PIP_JSON_URL = ('https://raw.githubusercontent.com/deanishe/'
+                'alfred-bundler/aries/meta/defaults/Pip.json')
+
+
+def _find_file(filename, start_dir=None):
+    """Find file named ``filename`` in the directory tree at ``start_dir``.
+
+    Climb up directory tree until ``filename`` is found. Raises IOError
+    if file is not found.
+
+    If ``start_dir`` is ``None``, start at current working directory.
+
+    :param filename: Name of the file to search for
+    :type filename: ``unicode`` or ``str``
+    :param start_dir: Path to starting directory. Default is current
+        working directory
+    :type start_dir: ``unicode`` or ``str``
+    :returns: Path to file or ``None``
+    :rtype: ``unicode`` or ``str``
+
+    """
+
+    curdir = start_dir or os.getcwd()
+    filepath = None
+    while True:
+        path = os.path.join(curdir, filename)
+        if os.path.exists(path):
+            filepath = path
+            break
+        if curdir == '/':
+            break
+        curdir = os.path.dirname(curdir)
+
+    if not filepath:
+        raise IOError(2, 'No such file or directory', filename)
+    return filepath
+
+
+def _bundle_id():
+    """Return bundle ID of current workflow
+
+    :returns: Bundle ID or ``None``
+    :rtype: ``unicode``
+
+    """
+
+    plist = plistlib.readPlist(_find_file('info.plist'))
+    return plist.get('bundleid', None)
+
+
+def _load_pip():
+    """Import ``pip``, installing it if necessary.
+
+    :returns: ``None``
+
+    """
+    if not os.path.exists(PIP_JSON_PATH):
+        urlretrieve(PIP_JSON_URL, PIP_JSON_PATH)
+
+    assert os.path.exists(PIP_JSON_PATH), ('Error retrieving Pip recipe '
+                                           'from GitHub.')
+
+    # This isn't working. `bundler.sh` appears to drop custom JSON
+    # paths on the floor and only work with things specified in
+    # its own `meta/defaults`
+    pip_path = utility('Pip', json_path=PIP_JSON_PATH)
+    print('pip_path : {}'.format(pip_path))
+
+    sys.path.insert(0, pip_path)
+    import pip
+
+
+def _bootstrap():
+    """Check if bundler bash wrapper and ``pip`` are installed
+    and install them if not.
+
+    NOTE: This will not actuall install the bundler. That will happen the
+    first time `~bundler.utility()`, `~bundler.init()` or
+    `~bundler._load_pip()` is called.
+
+    :returns: ``None``
+
+    """
+
+    if os.path.exists(HELPER_PATH):  # Already installed
+        return
+
+    # Create local directory if necessary
+    if not os.path.exists(HELPER_DIR):
+        os.makedirs(HELPER_DIR)
+
+    # Install installer.sh from GitHub
+    urlretrieve(HELPER_URL, HELPER_PATH)
+
+    assert os.path.exists(HELPER_PATH), ('Error bootstrapping bundler. '
+                                         'Could not download helper script '
+                                         'from GitHub.')
+
+
+def utility(name, version='default', json_path=None):
+    """Get path to specified utility or asset, installing it if necessary.
+
+    :param name: Name of the utility/asset to install
+    :type name: ``unicode`` or ``str``
+    :param version: Desired version of the utility/asset.
+    :type version: ``unicode`` or ``str``
+    :param json_path: Path to bundler configuration file
+    :type json_path: ``unicode`` or ``str``
+    :returns: Path to utility
+    :rtype: ``unicode``
+
+    """
+
+    _bootstrap()
+    # Call bash wrapper with specified arguments
+    json_path = json_path or ''
+    cmd = ['/bin/bash', HELPER_PATH, name, version, 'utility', json_path]
+    path = subprocess.check_output(cmd).strip()
+    # bundler.sh is broken and returns an error message if something goes
+    # wrong instead of exiting uncleanly, so check that path exists, else
+    # treat it as an error message
+    if not os.path.exists(path):  # Is probably an error message
+        # Simulate error that would be raised if `bundler.sh`
+        # behaved properly
+        raise subprocess.CalledProcessError(-1, cmd, path)
+    return path
+
+
+def asset(name, version='default', json_path=None):
+    """Synonym for `~bundler.utility()`"""
+    return utility(name, version, json_path)
+
+
+def init(requirements=None):
+    """Install dependencies from ``requirements.txt``.
+
+    Will search directory tree for ``requirements.txt`` if ``requirements``
+    is not specified.
+
+    :param requirements: Path to ``requirements.txt``
+    :type requirements: ``unicode`` or `str``
+    :returns: ``None``
+
+    """
+    _bootstrap()
+    bundle_id = _bundle_id()
+    if not bundle_id:
+        raise ValueError('You *must* set a bundle ID in your workflow '
+                         'to use this library.')
+
+    install_dir = os.path.join(PYTHON_LIB_DIR, bundle_id)
+    if not os.path.exists(install_dir):
+        os.makedirs(install_dir)
+
+    requirements = requirements or _find_file('requirements.txt')
+
+    # Call `pip`
+    _load_pip()

--- a/wrappers/bundler.py
+++ b/wrappers/bundler.py
@@ -212,7 +212,7 @@ def _bootstrap():
     """Check if bundler bash wrapper and ``pip`` are installed
     and install them if not.
 
-    NOTE: This will not actuall install the bundler. That will happen the
+    NOTE: This will not actually install the bundler. That will happen the
     first time :func:`~bundler.utility()`, `~bundler.init()` or
     :func:`~bundler._add_pip_path()` is called.
 

--- a/wrappers/bundler.py
+++ b/wrappers/bundler.py
@@ -3,10 +3,106 @@
 
 
 """
-Python implementation of the Alfred Bundler.
+#########################
+Alfred Bundler for Python
+#########################
 
-NOTE: The installation of Python libraries is currently unfinished due
-to the bundler.sh script it depends on being broken.
+Alfred Bundler is a framework to help workflow authors manage external
+utilities and libraries required by their workflows without having to
+include them with each and every workflow.
+
+`Alfred Bundler Homepage/Documentation <http://shawnrice.github.io/alfred-bundler/>`_.
+
+**NOTE**: By necessity, this Python implementation does not work in
+exactly the same way as the reference PHP/bash implementations by
+Shawn Rice.
+
+The purpose of the Bundler is to enable workflow authors to easily
+access utilites and libraries that are commonly used without having to
+include a copy in every ``.alfredworkflow`` file or worry about installing
+them themselves. This way, we can hopefully avoid having, say, 15 copies
+of ``cocaoDialog`` clogging up users' Dropboxes, and also allow authors to
+distribute workflows with sizeable requirements without their exceeding
+GitHub's 10 MB limit for ``.alfredworkflow`` files or causing authors
+excessive bandwidth costs.
+
+Unfortunately, due to the nature of Python's import system, it isn't
+possible to provide versioned libraries in the way that the PHP Bundler
+does, so this version of the Bundler creates an individual library
+directory for each workflow and adds it to ``sys.path`` with one simple call.
+
+It is based on `Pip <http://pip.readthedocs.org/en/latest/index.html>`_,
+the de facto Python library installer, and you must create a
+``requirements.txt`` file in `the format required by pip <http://pip.readthedocs.org/en/latest/user_guide.html#requirements-files>`_
+in order to take advantage of automatic dependency installation.
+
+Usage
+======
+
+The Python Bundler provides two main features: the ability to use common
+utility programs (e.g. `cocaoDialog <http://mstratman.github.io/cocoadialog/>`_
+or `Pashua <http://www.bluem.net/en/mac/pashua/>`_) simply by asking for
+them by name (they will automatically be installed if necessary), and the
+ability to automatically install and update any Python libraries required
+by your workflows.
+
+Simply include this ``bundler.py`` file (from the Alfred Bundler's ``wrappers``
+directory) alongside your workflow's Python code where it can be imported.
+
+Using utilities/assets
+----------------------
+
+The basic interface for utilities is::
+
+    import bundler
+    util_path = bundler.utility('utilityName')
+
+which will return the path to the appropriate executable, installing
+it first if necessary. You may optionally specify a version number
+and/or your own JSON file that defines a non-standard utility.
+
+Please see `the Alfred Bundler documentation <http://shawnrice.github.io/alfred-bundler/>`_
+for details of the JSON file format and how the Bundler works in general.
+
+Handling Python dependencies
+----------------------------
+
+The Python Bundler can also take care of your workflow's dependencies for
+you if you create a `requirements.txt <http://pip.readthedocs.org/en/latest/user_guide.html#requirements-files>`_
+file in your workflow root directory and put the following in your Python
+source files before trying to import any of those dependencies::
+
+    import bundler
+    bundler.init()
+
+:func:`~bundler.init()` will find your ``requirements.txt``  file (you may alternatively
+specify the path explicitly—see :func:`~bundler.init()`)
+and call Pip with it (installing Pip first if necessary). Then it will
+add the directory it's installed the libraries in to ``sys.path``, so you
+can immediately ``import`` those libraries::
+
+    import bundler
+    bundler.init()
+    import requests  # specified in `requirements.txt`
+
+The Bundler doesn't define any explicit exceptions, but may raise any number
+of different ones (e.g. :class:`~exceptions.IOError` if a file doesn't
+exist or if the computer or PyPi is offline).
+
+By and large, these are not recoverable errors, but if you'd like to ensure
+your workflow's users are notified, I recommend (shameless plug) building
+your Python workflow with
+`Alfred-Workflow <http://www.deanishe.net/alfred-workflow/>`_,
+which can catch workflow errors and warn the user (amongst other cool stuff).
+
+Any problems with the Bundler may be raised on
+`Alfred's forum <http://www.alfredforum.com/topic/4255-alfred-dependency-downloader-framework/>`_
+or on `GitHub <https://github.com/shawnrice/alfred-bundler>`_. **Note:**
+This Python version currently only exists in `this fork <https://github.com/deanishe/alfred-bundler>`_, so it's
+currently better to raise problems specific to the Python version there.
+
+Alfred Bundler Methods
+======================
 
 """
 
@@ -107,11 +203,7 @@ def _add_pip_path():
     assert os.path.exists(PIP_JSON_PATH), ('Error retrieving Pip recipe '
                                            'from GitHub.')
 
-    # This isn't working. `bundler.sh` appears to drop custom JSON
-    # paths on the floor and only work with things specified in
-    # its own `meta/defaults`
     pip_path = utility('Pip', json_path=PIP_JSON_PATH)
-    print('pip_path : {}'.format(pip_path))
 
     sys.path.insert(0, pip_path)
 
@@ -121,8 +213,8 @@ def _bootstrap():
     and install them if not.
 
     NOTE: This will not actuall install the bundler. That will happen the
-    first time `~bundler.utility()`, `~bundler.init()` or
-    `~bundler._load_pip()` is called.
+    first time :func:`~bundler.utility()`, `~bundler.init()` or
+    :func:`~bundler._add_pip_path()` is called.
 
     :returns: ``None``
 
@@ -144,7 +236,20 @@ def _bootstrap():
 
 
 def utility(name, version='default', json_path=None):
-    """Get path to specified utility or asset, installing it if necessary.
+    """Get path to specified utility or asset, installing it first if necessary.
+
+    Use this method to access common command line utilities, such as
+    `cocaoDialog <http://mstratman.github.io/cocoadialog/>`_ or
+    `Terminal-Notifier <https://github.com/alloy/terminal-notifier>`_.
+
+    This function will return the path to the appropriate executable
+    (installing it first if necessary), which you can then utilise via
+    :mod:`subprocess`.
+
+    You can easily add your own utilities by means of JSON configuration
+    files specified with the ``json_path`` argument. Please see
+    `the Alfred Bundler documentation <http://shawnrice.github.io/alfred-bundler/>`_
+    for details of the JSON file format.
 
     :param name: Name of the utility/asset to install
     :type name: ``unicode`` or ``str``
@@ -161,7 +266,7 @@ def utility(name, version='default', json_path=None):
     # Call bash wrapper with specified arguments
     json_path = json_path or ''
     cmd = ['/bin/bash', HELPER_PATH, name, version, 'utility', json_path]
-    path = subprocess.check_output(cmd).strip()
+    path = subprocess.check_output(cmd).strip().decode('utf-8')
     # bundler.sh is broken and returns an error message if something goes
     # wrong instead of exiting uncleanly, so check that path exists, else
     # treat it as an error message
@@ -173,18 +278,26 @@ def utility(name, version='default', json_path=None):
 
 
 def asset(name, version='default', json_path=None):
-    """Synonym for `~bundler.utility()`"""
+    """Synonym for :func:`~bundler.utility()`"""
     return utility(name, version, json_path)
 
 
 def init(requirements=None):
-    """Install dependencies from ``requirements.txt``.
+    """Install dependencies from ``requirements.txt`` to your workflow's
+    custom bundler directory and add this directory to ``sys.path``.
 
-    Will search directory tree for ``requirements.txt`` if ``requirements``
-    is not specified.
+    Will search up the directory tree for ``requirements.txt`` if
+    ``requirements`` argument is not specified.
 
-    :param requirements: Path to ``requirements.txt``
-    :type requirements: ``unicode`` or `str``
+    **Note:** Your workflow must have a bundle ID set in order to use
+    this function. (You should set one anyway, especially if you intend
+    to distribute your workflow.)
+
+    Your ``requirements.txt`` file must be in the
+    `format required by Pip <http://pip.readthedocs.org/en/latest/user_guide.html#requirements-files>`_.
+
+    :param requirements: Path to Pip requirements file
+    :type requirements: ``unicode`` or ``str``
     :returns: ``None``
 
     """


### PR DESCRIPTION
#### Handle JSON files (shawnrice/alfred-bundler#1)

`bundler.sh` now correctly handles a JSON file if passed on in the arguments.
#### Improve error handling/error messages (shawnrice/alfred-bundler#2)
- Return appropriate exit code from `__loadAsset`.
- Pass through exit code of `__loadAsset` as script exit status in `alfred.bundler.misc.sh` (Similar changes are presumably necessary in `alfred.bundler.sh`, but I haven't made them).
- Return specific error message if the JSON file isn't found.
#### Python bundler

Add Python near-equivalent bundler wrapper
- Utilities/assets work as in bash/PHP bundlers
- Cannot handle versioned Python libraries, but installs a different set for each workflow (based on bundle ID)
- Uses Pip and its `requirements.txt` to specify dependencies
- Automatically updates installed libraries if `requirements.txt` has changed
